### PR TITLE
Fix missing padding in ActionStripVlan

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2011-11-11  Vimal  <j.vimal@gmail.com>
+
+	* src/openfaucet/ofaction.py: Added missing padding in ActionStripVlan
+
 2011-05-24  Romain Lenglet  <romain.lenglet@berabera.info>
 
 	* src/openfaucet/ofconfig.py: Fix documentation of PortConfig

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ OpenFaucet NEWS - User visible changes.
 ** Removed the deadlock when accessing property features in a
    controller's connection_made() callback.
 
+** Added missing padding in ActionStripVlan
 
 Copyright 2011 Midokura KK
 

--- a/src/openfaucet/ofaction.py
+++ b/src/openfaucet/ofaction.py
@@ -198,7 +198,7 @@ class ActionSetVlanPcp(__action('ActionSetVlanPcp', OFPAT_SET_VLAN_PCP,
         return a
 
 
-ActionStripVlan = __action('ActionStripVlan', OFPAT_STRIP_VLAN, '', ())
+ActionStripVlan = __action('ActionStripVlan', OFPAT_STRIP_VLAN, '4x', ())
 
 
 ActionSetDlSrc = __action('ActionSetDlSrc', OFPAT_SET_DL_SRC,


### PR DESCRIPTION
Actions must be at least 8 bytes in size and should be padded with 0s.
